### PR TITLE
Add autoloads to most common entrypoint commands

### DIFF
--- a/phi-replace.el
+++ b/phi-replace.el
@@ -140,6 +140,7 @@
 
 ;; * commands
 
+;;;###autoload
 (defun phi-replace ()
   "replace command using phi-search"
   (interactive)

--- a/phi-search.el
+++ b/phi-search.el
@@ -374,6 +374,7 @@ returns the position of the item, or nil for failure."
 
 ;; * interactive commands
 
+;;;###autoload
 (defun phi-search ()
   "incremental search command compatible with \"multiple-cursors\""
   (interactive)
@@ -382,6 +383,7 @@ returns the position of the item, or nil for failure."
       (call-interactively 'isearch-forward-regexp)
     (phi-search--initialize)))
 
+;;;###autoload
 (defun phi-search-backward ()
   "incremental search command compatible with \"multiple-cursors\""
   (interactive)


### PR DESCRIPTION
This way phi-search works more smoothly with the emacs package manager.
