### PR TITLE
A problem with zero-width matches

### DIFF
--- a/phi-search.el
+++ b/phi-search.el
@@ -107,6 +107,16 @@
 (set-face-attribute 'phi-search-selection-face nil
                     :background "#594854")
 
+;; * variables
+
+(defvar phi-search--last-executed nil
+  "stores the last query")
+(make-variable-buffer-local 'phi-search--last-executed)
+
+(defvar phi-search--target nil
+  "the target (window . buffer) which this prompt buffer is for")
+(make-variable-buffer-local 'phi-search--target)
+
 ;; * utilities
 
 (defun phi-search--search-backward (query limit &optional inclusive)
@@ -158,10 +168,6 @@
   "stores which item is currently selected.
 this value must be nil, if nothing is matched.")
 (make-variable-buffer-local 'phi-search--selection)
-
-(defvar phi-search--last-executed nil
-  "stores the last query")
-(make-variable-buffer-local 'phi-search--last-executed)
 
 ;; functions
 
@@ -232,10 +238,6 @@ returns the position of the item, or nil for failure."
 (make-variable-buffer-local 'phi-search--direction)
 
 ;; variables
-
-(defvar phi-search--target nil
-  "the target (window . buffer) which this prompt buffer is for")
-(make-variable-buffer-local 'phi-search--target)
 
 (defvar phi-search--mode-line-format
   '(" *phi-search*"


### PR DESCRIPTION
Suppose you have a buffer like this:

```
a
b

c
d

e
```

Then type `M-x phi-replace RET $ RET ! RET`, and the buffer is updated as follows:

```
a!
b
!
c!
d
!
e
```

Some positions are missed out, presumably where the position N and the position N+1 both match the pattern.
