### PR TITLE
Support recenter on C-l

### DIFF
--- a/phi-search.el
+++ b/phi-search.el
@@ -94,6 +94,7 @@
     (define-key map (kbd "C-n") 'phi-search-maybe-next-line)
     (define-key map (kbd "C-p") 'phi-search-maybe-previous-line)
     (define-key map (kbd "C-f") 'phi-search-maybe-forward-char)
+    (define-key map (kbd "C-l") 'phi-search-recenter-top-bottom)
     (define-key map (kbd "RET") 'phi-search-complete)
     map)
   "keymap for the phi-search prompt buffers"
@@ -412,6 +413,11 @@ returns the position of the item, or nil for failure."
     (if (not (string= (buffer-string) ""))
         (phi-search-next)
       (insert str))))
+
+(defun phi-search-recenter-top-bottom ()
+  (interactive)
+  (phi-search--with-target-buffer
+   (recenter-top-bottom)))
 
 (defun phi-search-again-or-previous ()
   "search again with the last query, or search previous item"


### PR DESCRIPTION
Hi there,

Since the edit buffer will typically be small, we can assume that when pressing C-l, the user doesn't really wish to recenter the edit buffer, but the target buffer.  This is how isearch behaves as well.  Personally I have this behavior in my muscle memory, and would like to see this in phi-search as well.

Thanks,
PM
