### PR TITLE
Support recenter on C-l

### DIFF
--- a/phi-search.el
+++ b/phi-search.el
@@ -95,6 +95,7 @@
     (define-key map (kbd "C-p") 'phi-search-maybe-previous-line)
     (define-key map (kbd "C-f") 'phi-search-maybe-forward-char)
     (define-key map (kbd "C-l") 'phi-search-recenter-top-bottom)
+    (define-key map (kbd "C-w") 'phi-search-yank-word)
     (define-key map (kbd "RET") 'phi-search-complete)
     map)
   "keymap for the phi-search prompt buffers"
@@ -484,6 +485,22 @@ if optional arg command is non-nil, call it after that."
   (interactive)
   (phi-search--with-target-buffer
    (recenter-top-bottom)))
+
+(defun phi-search-yank-word ()
+  "If there's a region in search buffer, yank from that.
+Otherwise yank from target buffer and expand search string."
+  (interactive)
+  (if (or (not (use-region-p))
+	  (= (region-beginning) (region-end)))
+      (let ((str (phi-search--with-target-buffer
+		  (save-excursion
+		    (let ((start-point (point))
+			  (end-point (progn (forward-word 1) (point))))
+		      (buffer-substring-no-properties
+		       start-point end-point))))))
+	(insert str))
+
+    (kill-region (region-beginning) (region-end))))
 
 ;; * provide
 


### PR DESCRIPTION
Hi there,

OK, this merge request thing works differently than I imagined.  I guess I didn't need to close the previous merge request, and this one will end up being a merge of two commits.

This adds some functionality that's missing from phisearch as compared to isearch.  First is C-l for recenter, second is C-w for yank.  The former, I believe, is uncontroversial.

The latter is a bit problematic, as the user might want to use C-w to edit the search buffer itself, so we first check whether there's an active region.  Both of these commands I have in my muscle memory and feel should be in phisearch.

Thanks,
PM
