### PR TITLE
phi-search and phi-search-backward accept prefix argument

### DIFF
--- a/phi-search.el
+++ b/phi-search.el
@@ -238,11 +238,12 @@
 ;; + commands
 
 ;;;###autoload
-(defun phi-search ()
+(defun phi-search (&optional use-isearch)
   "incremental search command compatible with \"multiple-cursors\""
-  (interactive)
-  (if (or (not (boundp 'popwin:popup-window))
-          (not (eq (selected-window) popwin:popup-window)))
+  (interactive "P")
+  (if (and (not use-isearch)
+           (or (not (boundp 'popwin:popup-window))
+               (not (eq (selected-window) popwin:popup-window))))
       (phi-search--search-initialize nil)
     (call-interactively 'isearch-forward-regexp)
     (when (use-region-p)
@@ -252,11 +253,12 @@
         (isearch-yank-string string)))))
 
 ;;;###autoload
-(defun phi-search-backward ()
+(defun phi-search-backward (&optional use-isearch)
   "incremental search command compatible with \"multiple-cursors\""
-  (interactive)
-  (if (or (not (boundp 'popwin:popup-window))
-          (not (eq (selected-window) popwin:popup-window)))
+  (interactive "P")
+  (if (and (not use-isearch)
+           (or (not (boundp 'popwin:popup-window))
+               (not (eq (selected-window) popwin:popup-window))))
       (phi-search--search-initialize t)
     (call-interactively 'isearch-backward-regexp)
     (when (use-region-p)


### PR DESCRIPTION
Added prefix argument handling to phi-search and phi-search-backward. If
prefix argument is non-nil, then search using isearch instead. This
allows binding of phi-search to [C-s] by default, while allowing normal
isearch with [C-u C-s].
