### PR TITLE
Correct eval-after-load usage

### DIFF
--- a/phi-search.el
+++ b/phi-search.el
@@ -153,7 +153,7 @@
 
 (defvar phi-search--region-query nil
   "query for a generated command, must be cursor-local")
-(eval-after-load "multiple-cursors"
+(eval-after-load 'multiple-cursors
   '(add-to-list 'mc/cursor-specific-vars 'phi-search--region-query))
 
 (defun phi-search--generate-command (query n &optional filter cmd use-region)


### PR DESCRIPTION
Hello,

If you have a file named "multiple-cursors.el" and you load it, phi-search will trigger the eval-after-load block about `mc/cursor-specific-vars` and if multiple-cursors isn't loaded it creates an error about unknown variable.

The correct way to use eval-after-load is the symbol form, which waits until something `provide` this symbol.
