### PR TITLE
Fix search with region

### DIFF
--- a/phi-search-core.el
+++ b/phi-search-core.el
@@ -411,7 +411,8 @@ Otherwise yank a word from target buffer and expand query."
 ;; + start/end phi-search
 
 (defun phi-search--initialize (modeline-fmt keybinds filter-fn
-                                            update-fn complete-fn &optional conv-fn)
+                                            update-fn complete-fn
+                                            &optional conv-fn init-fn)
   (setq phi-search--saved-modeline-format  mode-line-format)
   (setq mode-line-format                   modeline-fmt
         phi-search--original-position      (point)
@@ -427,7 +428,8 @@ Otherwise yank a word from target buffer and expand query."
           (setq phi-search--target                   (cons wnd buf)
                 phi-search--convert-query-function   conv-fn
                 phi-search--before-complete-function complete-fn)
-          (run-hooks 'phi-search-hook))
+          (run-hooks 'phi-search-hook)
+          (funcall init-fn))
       (read-from-minibuffer
        "phi-search: " nil
        (let ((kmap (copy-keymap phi-search-default-map)))

--- a/phi-search.el
+++ b/phi-search.el
@@ -230,9 +230,11 @@
        phi-search-additional-keybinds)
      nil
      (when backward 'phi-search--backward-after-update-function)
-     'phi-search--complete-function)
-    (when str (insert str)))
-  (run-hooks 'phi-search-init-hook))
+     'phi-search--complete-function
+     nil
+     (lambda ()
+       (when str (insert str))
+       (run-hooks 'phi-search-init-hook)))))
 
 ;; + commands
 


### PR DESCRIPTION
Phi-search now uses minibuffer and `phi-search--initialize` no longer returns immediately, so you cannot simply call `phi-search--initialize` and `(insert str)` etc. in sequence.