### PR TITLE
workaround for phi-search--active lying

### DIFF
--- a/phi-search-core.el
+++ b/phi-search-core.el
@@ -464,7 +464,7 @@ Otherwise yank a word from target buffer and expand query."
 
 (defun phi-search--initialize (modeline-fmt keybinds filter-fn update-fn
                                             complete-fn &optional conv-fn init-fn prompt)
-  (if phi-search--active
+  (if (and phi-search--active (active-minibuffer-window))
       ;; if phi-search is already active, just switch to the minibuffer
       (select-window (active-minibuffer-window))
     (let ((wnd (selected-window))


### PR DESCRIPTION
Sometimes it will be non-nil, but `(active-minubuffer-window)` will return
`nil`

This is only a workaround that caused my phi-search to stop breaking, but after having this issue a couple of times, I thought you might want to provide a hotfix until the bug is correctly solved :)