### PR TITLE
Work around problematic push macro in Emacs 23

### DIFF
--- a/phi-search-core.el
+++ b/phi-search-core.el
@@ -246,9 +246,9 @@ omitted or nil, number of matches is limited to
         (while (and (phi-search--search-forward query nil phi-search--filter-function)
                     (let ((ov (make-overlay (match-beginning 0) (match-end 0))))
                       (overlay-put ov 'face 'phi-search-match-face)
-                      (push ov (if (< (match-beginning 0) phi-search--original-position)
-                                   before
-                                 after))
+                      (if (< (match-beginning 0) phi-search--original-position)
+                          (push ov before)
+                        (push ov after))
                       (setq cnt (1+ cnt))
                       (or unlimited (< cnt phi-search-limit)))))
         (setq phi-search--overlays (nconc (nreverse after) (nreverse before)))))


### PR DESCRIPTION
In Emacs 23.4, phi-search fails with a stack trace like this:

```
Debugger entered--Lisp error: (wrong-type-argument symbolp (if (< (match-beginning 0) phi-search--original-position) before after))
  (setq (if (< ... phi-search--original-position) before after) (cons ov (if ... before after)))
  (push ov (if (< ... phi-search--original-position) before after))
  (let ((ov ...)) (overlay-put ov (quote face) (quote phi-search-match-face)) (push ov (if ... before after)) (setq cnt (1+ cnt)) (or unlimited (< cnt phi-search-limit)))
  (and (phi-search--search-forward query nil phi-search--filter-function) (let (...) (overlay-put ov ... ...) (push ov ...) (setq cnt ...) (or unlimited ...)))
  (while (and (phi-search--search-forward query nil phi-search--filter-function) (let ... ... ... ... ...)))
  (let ((before nil) (after nil) (cnt 0)) (goto-char (point-min)) (while (and ... ...)) (setq phi-search--overlays (nconc ... ...)))
  (save-excursion (let (... ... ...) (goto-char ...) (while ...) (setq phi-search--overlays ...)))
  (cond ((not ...) (setq phi-search--failed ...) (phi-search--message "invalid input")) (t (save-excursion ...) (let ... ...)))
  phi-search--make-overlays-for("t")
  [...the rest of the stack trace elided for brevity...]
```

The push macro apparently behaves differently in Emacs 23 and 24
regarding when its arguments are evaluated.