### PR TITLE
Inherit isearch faces by default.

### DIFF
--- a/phi-search-core.el
+++ b/phi-search-core.el
@@ -96,14 +96,12 @@
 ;; + faces
 
 (defface phi-search-match-face
-  '((((background light)) (:background "#b5dee9"))
-    (t (:background "#194854")))
+  '((t (:inherit 'lazy-highlight)))
   "Face used to highlight matching items in phi-search."
   :group 'phi-search)
 
 (defface phi-search-selection-face
-  '((((background light)) (:background "#e0d9de"))
-    (t (:background "#594854")))
+  '((t (:inherit 'isearch)))
   "Face used to highlight selected items in phi-search."
   :group 'phi-search)
 


### PR DESCRIPTION
# Why

I've noticied that for many themes hardcoded values for phi-search match/lazy match are not really vizible.

# How

The suggested solution extends inheritance of one variable to two more variables. This way we will always follow up isearch convention (which is the most theme authors define properly).
